### PR TITLE
fix : Property 에서 공백 문자열로 대체

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -91,8 +91,8 @@ jib{
         image = 'docker.io/ghkd110/techeer_log'
         tags = ['latest', 'test']
         auth {
-            username = findProperty('jib.to.auth.username') ?: " " as Property<String>
-            password = findProperty('jib.to.auth.password') ?: " " as Property<String>
+            username = findProperty('jib.to.auth.username') ?: " "
+            password = findProperty('jib.to.auth.password') ?: " "
 
             if (username == " " || password == " ") {
                 logger.warn("gradle.properties 파일이 있는지 확인")


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [ ] 🌈 알록달록한가요?

## 작업 내용

파일이 존재하지 않을 시 기본 문자열을 넣기 위해서  gradle 함수인 Property를 사용했는데, 특정 버전이나 환경에서 제대로 사용할 수 없다는 문제점 발생 

-> 중요한 내용은 아니므로 그냥 공백 문자열로 대체

## 스크린샷

## 주의사항

Closes #414 