### PR TITLE
[fix] 8월 23일 이전 로그인이 되지 않는 회원들에 대한 로그인 구현

### DIFF
--- a/backend/src/main/java/com/techeerlog/auth/domain/encryptor/Encryptor.java
+++ b/backend/src/main/java/com/techeerlog/auth/domain/encryptor/Encryptor.java
@@ -9,10 +9,11 @@ import java.security.NoSuchAlgorithmException;
 
 public class Encryptor implements EncryptorI {
 
-    public Encryptor() {}
+    private final String salt;
 
-    @Value("${salt}")
-    private String salt;
+    public Encryptor(String salt) {
+        this.salt = salt;
+    }
 
     @Override
     public String encrypt(String text) {

--- a/backend/src/main/java/com/techeerlog/auth/domain/encryptor/EncryptorFactory.java
+++ b/backend/src/main/java/com/techeerlog/auth/domain/encryptor/EncryptorFactory.java
@@ -1,12 +1,19 @@
 package com.techeerlog.auth.domain.encryptor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class EncryptorFactory {
+
     @Bean
-    public EncryptorI getEncryptor() {
-        return new Encryptor();
+    public EncryptorI getOldEncryptor(@Value("${common.salt.old}") String salt) {
+        return new Encryptor(salt);
+    }
+
+    @Bean
+    public EncryptorI getNewEncryptor(@Value("${common.salt.new}") String salt) {
+        return new Encryptor(salt);
     }
 }

--- a/backend/src/main/java/com/techeerlog/auth/service/AuthService.java
+++ b/backend/src/main/java/com/techeerlog/auth/service/AuthService.java
@@ -6,24 +6,33 @@ import com.techeerlog.auth.dto.LoginRequest;
 import com.techeerlog.auth.exception.LoginFailedException;
 import com.techeerlog.member.domain.Member;
 import com.techeerlog.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
+
 public class AuthService {
 
     private final MemberRepository memberRepository;
-    private final EncryptorI encryptor;
+    private final EncryptorI oldEncryptor;
+    private final EncryptorI newEncryptor;
 
-    public AuthService(MemberRepository memberRepository, EncryptorI encryptor) {
+    public AuthService(MemberRepository memberRepository, @Qualifier("getOldEncryptor") EncryptorI oldEncryptor, @Qualifier("getNewEncryptor") EncryptorI newEncryptor) {
         this.memberRepository = memberRepository;
-        this.encryptor = encryptor;
+        this.oldEncryptor = oldEncryptor;
+        this.newEncryptor = newEncryptor;
     }
 
     public AuthInfo login(LoginRequest loginRequest) {
-        String loginId = loginRequest.getLoginId();
-        String password = encryptor.encrypt(loginRequest.getPassword());
-        Member member = memberRepository.findByLoginIdValueAndPasswordValue(loginId, password)
+        Member member = memberRepository.findByLoginIdValue(loginRequest.getLoginId())
                 .orElseThrow(LoginFailedException::new);
+
+        EncryptorI chosenEncryptor = member.isSaltNew() ? newEncryptor : oldEncryptor;
+        String hashedPassword = chosenEncryptor.encrypt(loginRequest.getPassword());
+        if (!hashedPassword.equals(member.getPassword())) {
+            throw new LoginFailedException();
+        }
+
         return new AuthInfo(member.getId(), member.getRoleType().getName(), member.getNickname());
     }
 }

--- a/backend/src/main/java/com/techeerlog/global/support/DummyMethod.java
+++ b/backend/src/main/java/com/techeerlog/global/support/DummyMethod.java
@@ -59,13 +59,13 @@ public class DummyMethod {
     private void createMembers() {
         List<Member> members = Arrays.asList(
                 new Member(1L, new LoginId("test1"), new Password("1234"), new Nickname("test1"),
-                        "profileImageUrl1", "introduction1"),
+                        "profileImageUrl1", "introduction1", true),
                 new Member(2L, new LoginId("test2"), new Password("1234"), new Nickname("test2"),
-                        "profileImageUrl2", "introduction2"),
+                        "profileImageUrl2", "introduction2",true),
                 new Member(3L, new LoginId("test3"), new Password("1234"), new Nickname("test3"),
-                        "profileImageUrl3", "introduction3"),
+                        "profileImageUrl3", "introduction3", true),
                 new Member(4L, new LoginId("test4"), new Password("1234"), new Nickname("test4"),
-                        "profileImageUrl4", "introduction4")
+                        "profileImageUrl4", "introduction4",true)
         );
         memberRepository.saveAll(members);
     }

--- a/backend/src/main/java/com/techeerlog/member/domain/Member.java
+++ b/backend/src/main/java/com/techeerlog/member/domain/Member.java
@@ -94,4 +94,8 @@ public class Member extends BaseEntity {
     public boolean hasId(Long id) {
         return this.id.equals(id);
     }
+
+    public void updateIsSaltNew(boolean isSaltNew) {
+        this.isSaltNew = isSaltNew;
+    }
 }

--- a/backend/src/main/java/com/techeerlog/member/domain/Member.java
+++ b/backend/src/main/java/com/techeerlog/member/domain/Member.java
@@ -41,6 +41,9 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoleType roleType = RoleType.USER;
 
+    @Getter
+    private boolean isSaltNew;
+
     public String getLoginId() {
         return loginId.getValue();
     }
@@ -56,14 +59,19 @@ public class Member extends BaseEntity {
     public Member() {
     }
 
+    /**
+     * Salt값이 옛버전인지, 신버전인지를 나눴다. 변경하지 않는 이상 old를 쓰는거지.
+     *
+     */
 
     @Builder
-    public Member(Long id, LoginId loginId, Password password, Nickname nickname, String profileImageUrl, String introduction) {
+    public Member(Long id, LoginId loginId, Password password, Nickname nickname, String profileImageUrl, String introduction, boolean isSaltNew) {
         this.id = id;
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.isSaltNew = isSaltNew;
         this.introduction = introduction != null ? introduction : "";
     }
 
@@ -87,6 +95,3 @@ public class Member extends BaseEntity {
         return this.id.equals(id);
     }
 }
-
-
-

--- a/backend/src/main/java/com/techeerlog/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/techeerlog/member/repository/MemberRepository.java
@@ -13,5 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsMemberByNicknameValue(String nickname);
 
-    Optional<Member> findByLoginIdValueAndPasswordValue(String loginId, String password);
+    Optional<Member> findByLoginIdValue(String loginId);
 }

--- a/backend/src/main/java/com/techeerlog/member/service/MemberService.java
+++ b/backend/src/main/java/com/techeerlog/member/service/MemberService.java
@@ -24,11 +24,14 @@ public class MemberService extends BaseEntity {
 
     private final MemberRepository memberRepository;
     private final EncryptorI newEncryptor;
+    private final EncryptorI oldEncryptor;
     private final AmazonS3Service amazonS3Service;
 
-    public MemberService(MemberRepository memberRepository, @Qualifier("getNewEncryptor") EncryptorI newEncryptor, AmazonS3Service amazonS3Service) {
+
+    public MemberService(MemberRepository memberRepository, @Qualifier("getOldEncryptor") EncryptorI oldEncryptor, @Qualifier("getNewEncryptor") EncryptorI newEncryptor, AmazonS3Service amazonS3Service) {
         this.memberRepository = memberRepository;
         this.newEncryptor = newEncryptor;
+        this.oldEncryptor = oldEncryptor;
         this.amazonS3Service = amazonS3Service;
     }
 
@@ -133,26 +136,28 @@ public class MemberService extends BaseEntity {
 
     @Transactional
     public void updatePassword(AuthInfo authInfo, UpdatePasswordRequest updatePasswordRequest) {
-        // 기존 비밀번호를 찾기
+        // 회원 조회
         Member member = memberRepository.findById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
-        String password = member.getPassword();
-
-        // 기존 비밀번호와 요청으로 입력된 비밀번호가 일치한지 확인
+        String storedPassword = member.getPassword();
         String currentPassword = updatePasswordRequest.getCurrentPassword();
-        if(!password.equals(newEncryptor.encrypt(currentPassword))){
+
+        // 회원의 isSaltNew 플래그에 따라 적절한 Encryptor 선택
+        EncryptorI encryptorForCheck = member.isSaltNew() ? newEncryptor : oldEncryptor;
+
+        // 기존 비밀번호 검증
+        if (!storedPassword.equals(encryptorForCheck.encrypt(currentPassword))) {
             throw new IncorrectPasswordException();
         }
 
-        // 일치하다면 새로운 비밀번호가 유효한지 확인
+        // 새 비밀번호 처리 (필요시 추가 검증 가능)
         String newPassword = updatePasswordRequest.getNewPassword();
-//        Password.validate(newPassword);
+        // Password.validate(newPassword); // 유효성 검증
 
-        // 비밀번호 업데이트
+        // 비밀번호 업데이트 시, 최신 정책(NEW salt) 적용
         member.updateIsSaltNew(true);
         member.updatePassword(Password.of(newEncryptor, newPassword));
         memberRepository.save(member);
-
     }
 
 }

--- a/backend/src/main/java/com/techeerlog/member/service/MemberService.java
+++ b/backend/src/main/java/com/techeerlog/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.techeerlog.member.domain.Password;
 import com.techeerlog.member.dto.*;
 import com.techeerlog.member.exception.*;
 import com.techeerlog.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,12 +23,12 @@ import java.util.Optional;
 public class MemberService extends BaseEntity {
 
     private final MemberRepository memberRepository;
-    private final EncryptorI encryptor;
+    private final EncryptorI newEncryptor;
     private final AmazonS3Service amazonS3Service;
 
-    public MemberService(MemberRepository memberRepository, EncryptorI encryptor, AmazonS3Service amazonS3Service) {
+    public MemberService(MemberRepository memberRepository, @Qualifier("getNewEncryptor") EncryptorI newEncryptor, AmazonS3Service amazonS3Service) {
         this.memberRepository = memberRepository;
-        this.encryptor = encryptor;
+        this.newEncryptor = newEncryptor;
         this.amazonS3Service = amazonS3Service;
     }
 
@@ -38,9 +39,10 @@ public class MemberService extends BaseEntity {
 
         Member member = Member.builder()
                 .loginId(new LoginId(signupRequest.getLoginId()))
-                .password(Password.of(encryptor, signupRequest.getPassword()))
+                .password(Password.of(newEncryptor, signupRequest.getPassword()))
                 .profileImageUrl(defaultProfileImageUrl)
                 .nickname(new Nickname(signupRequest.getNickname()))
+                .isSaltNew(true)
                 .build();
         memberRepository.save(member);
         return member;
@@ -138,7 +140,7 @@ public class MemberService extends BaseEntity {
 
         // 기존 비밀번호와 요청으로 입력된 비밀번호가 일치한지 확인
         String currentPassword = updatePasswordRequest.getCurrentPassword();
-        if(!password.equals(encryptor.encrypt(currentPassword))){
+        if(!password.equals(newEncryptor.encrypt(currentPassword))){
             throw new IncorrectPasswordException();
         }
 
@@ -147,7 +149,7 @@ public class MemberService extends BaseEntity {
 //        Password.validate(newPassword);
 
         // 비밀번호 업데이트
-        member.updatePassword(Password.of(encryptor, newPassword));
+        member.updatePassword(Password.of(newEncryptor, newPassword));
         memberRepository.save(member);
 
     }

--- a/backend/src/main/java/com/techeerlog/member/service/MemberService.java
+++ b/backend/src/main/java/com/techeerlog/member/service/MemberService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 @Service
 @Transactional
-public class MemberService extends BaseEntity {
+public class MemberService {
 
     private final MemberRepository memberRepository;
     private final EncryptorI newEncryptor;

--- a/backend/src/main/java/com/techeerlog/member/service/MemberService.java
+++ b/backend/src/main/java/com/techeerlog/member/service/MemberService.java
@@ -149,6 +149,7 @@ public class MemberService extends BaseEntity {
 //        Password.validate(newPassword);
 
         // 비밀번호 업데이트
+        member.updateIsSaltNew(true);
         member.updatePassword(Password.of(newEncryptor, newPassword));
         memberRepository.save(member);
 

--- a/backend/src/main/resources/application-deploy.yml
+++ b/backend/src/main/resources/application-deploy.yml
@@ -1,7 +1,9 @@
 server:
   port: ${COMMON.PORT}
 
-salt: ${COMMON.SALT}
+salt:
+  old: ${COMMON.SALT.OLD}
+  new: ${COMMON.SALT.NEW}
 
 spring:
   config:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,7 +1,9 @@
 server:
   port: ${COMMON.PORT}
 
-salt: ${COMMON.SALT}
+salt:
+  old: ${COMMON.SALT.OLD}
+  new: ${COMMON.SALT.NEW}
 
 spring:
   config:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,8 +1,9 @@
 server:
   port: ${COMMON.PORT}
 
-salt: ${COMMON.SALT}
-
+salt:
+  old: ${COMMON.SALT.OLD}
+  new: ${COMMON.SALT.NEW}
 spring:
   config:
     import: secret.yml


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [ ] 🌈 알록달록한가요?

## 작업 내용
Encryptor를 Salt 값에 따라서 다른 방식으로 처리하도록 로그인을 변경했습니다.

isSaltNew 컬럼의 값이 false라면, oldSalt의 값을 이용하고, true라면 newSalt의 값으로 로그인 로직을 처리합니다.

## 스크린샷


## 주의사항

Closes #{이슈 번호}
